### PR TITLE
Add export utilities and Celery support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ pydantic = "^2.9.2"
 openai = "^1.58.1"
 django-extensions = "^3.2.3"
 tenacity = "^9.1.2"
+celery = "^5.3"
 
 
 [build-system]

--- a/sell_that_sheet/sell_that_sheet/__init__.py
+++ b/sell_that_sheet/sell_that_sheet/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/sell_that_sheet/sell_that_sheet/celery.py
+++ b/sell_that_sheet/sell_that_sheet/celery.py
@@ -1,0 +1,8 @@
+import os
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sell_that_sheet.settings")
+
+app = Celery("sell_that_sheet")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/sell_that_sheet/sell_that_sheet/extra_views.py
+++ b/sell_that_sheet/sell_that_sheet/extra_views.py
@@ -1,0 +1,74 @@
+import os
+import tempfile
+from django.conf import settings
+from django.http import FileResponse
+from django.core.management import call_command
+from rest_framework.views import APIView
+from rest_framework.parsers import MultiPartParser
+from rest_framework.response import Response
+from rest_framework import status
+
+from .services.rows_to_columns import rows_to_columns
+from .tasks import export_allegro_catalogue_task, export_auctions_task
+
+
+class ConvertRowsToColumnsView(APIView):
+    parser_classes = [MultiPartParser]
+
+    def post(self, request):
+        uploaded = request.FILES.get("file")
+        if not uploaded:
+            return Response(
+                {"error": "No file provided"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as src:
+            for chunk in uploaded.chunks():
+                src.write(chunk)
+
+        dst = tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx")
+        try:
+            rows_to_columns(src.name, dst.name)
+            dst.seek(0)
+            response = FileResponse(
+                open(dst.name, "rb"), as_attachment=True, filename="converted.xlsx"
+            )
+        finally:
+            os.unlink(src.name)
+        return response
+
+
+class ExportAllegroStartView(APIView):
+    def post(self, request):
+        task = export_allegro_catalogue_task.delay()
+        return Response({"task_id": task.id})
+
+
+class DownloadAllegroExportView(APIView):
+    def get(self, request):
+        path = os.path.join(settings.BASE_DIR, "full_catalogue.xlsx")
+        if not os.path.exists(path):
+            return Response(
+                {"error": "File not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+        return FileResponse(
+            open(path, "rb"), as_attachment=True, filename="full_catalogue.xlsx"
+        )
+
+
+class ExportAuctionsView(APIView):
+    def get(self, request):
+        task = export_auctions_task.delay()
+        return Response({"task_id": task.id})
+
+
+class DownloadAuctionsExportView(APIView):
+    def get(self, request):
+        path = os.path.join(settings.BASE_DIR, "auctions_export.xlsx")
+        if not os.path.exists(path):
+            return Response(
+                {"error": "File not found"}, status=status.HTTP_404_NOT_FOUND
+            )
+        return FileResponse(
+            open(path, "rb"), as_attachment=True, filename="auctions_export.xlsx"
+        )

--- a/sell_that_sheet/sell_that_sheet/settings.py
+++ b/sell_that_sheet/sell_that_sheet/settings.py
@@ -130,7 +130,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-AUTH_USER_MODEL = 'sell_that_sheet.CustomUser'
+AUTH_USER_MODEL = "sell_that_sheet.CustomUser"
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
@@ -163,11 +163,11 @@ REST_FRAMEWORK = {
     ],
 }
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, 'static'),
+    os.path.join(BASE_DIR, "static"),
 ]
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 MEDIA_ROOT = os.environ["STS_MEDIA_ROOT"]
 APP_FILESYSTEM_ROOT = os.environ["STS_APP_FILESYSTEM_ROOT"]
@@ -186,10 +186,10 @@ OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
 OPENAI_TRANSLATION_ASSISTANT_ID = os.environ["OPENAI_TRANSLATION_ASSISTANT_ID"]
 PHOTOSET_MAX_PHOTOS = int(os.environ["PHOTOSET_MAX_PHOTOS"])
 
-SHIPMENT_WEIGHT_MAPPING = {
-    10: 15,
-    30: 15,
-    40: 40,
-    150: 150,
-    200: 200
-}
+SHIPMENT_WEIGHT_MAPPING = {10: 15, 30: 15, 40: 40, 150: 150, 200: 200}
+
+# Celery configuration
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.environ.get(
+    "CELERY_RESULT_BACKEND", "redis://localhost:6379/0"
+)

--- a/sell_that_sheet/sell_that_sheet/tasks.py
+++ b/sell_that_sheet/sell_that_sheet/tasks.py
@@ -1,0 +1,22 @@
+from celery import shared_task
+from django.conf import settings
+from .services.allegroconnector import AllegroConnector
+from django.core.management import call_command
+import os
+
+
+@shared_task
+def export_allegro_catalogue_task():
+    connector = AllegroConnector()
+    connector.get_allegro_access_token()
+    catalogue = connector.download_catalogue()
+    parsed = connector.parse_catalogue(catalogue)
+    output_path = os.path.join(settings.BASE_DIR, "full_catalogue.xlsx")
+    connector.export_to_xlsx(parsed, output_path)
+    return output_path
+
+
+@shared_task
+def export_auctions_task():
+    call_command("export_auctions")
+    return os.path.join(settings.BASE_DIR, "auctions_export.xlsx")

--- a/sell_that_sheet/sell_that_sheet/urls.py
+++ b/sell_that_sheet/sell_that_sheet/urls.py
@@ -25,15 +25,32 @@ from .views import (
     PrepareTagFieldPreview,
     PerformOcrView,
     ListGroupUsersView,
-    CompleteFilesView, CompleteAuctionSetFilesView, DescriptionTemplateViewSet,
-    GetUsersDescriptionTemplates, KeywordTranslationViewSet, GetUsersKeywordTranslation, KeywordTranslationSearchView,
+    CompleteFilesView,
+    CompleteAuctionSetFilesView,
+    DescriptionTemplateViewSet,
+    GetUsersDescriptionTemplates,
+    KeywordTranslationViewSet,
+    GetUsersKeywordTranslation,
+    KeywordTranslationSearchView,
     TranslateView,
     ImageRotateView,
     DistinctAuctionParameterView,
-    DistinctParameterView, SaveTranslationsView, ListTranslationsView,
-    TranslationExampleViewSet, TagViewSet, CategoryTagViewSet, CategoryParameterViewSet,
+    DistinctParameterView,
+    SaveTranslationsView,
+    ListTranslationsView,
+    TranslationExampleViewSet,
+    TagViewSet,
+    CategoryTagViewSet,
+    CategoryParameterViewSet,
     TranslateBaselinkerProductsView,
     BaselinkerInventoriesView,
+)
+from .extra_views import (
+    ConvertRowsToColumnsView,
+    ExportAllegroStartView,
+    DownloadAllegroExportView,
+    ExportAuctionsView,
+    DownloadAuctionsExportView,
 )
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
@@ -49,10 +66,12 @@ router.register(r"auctionparameters", AuctionParameterViewSet)
 router.register(r"parameters", ParameterViewSet)
 router.register(r"descriptiontemplate", DescriptionTemplateViewSet)
 router.register(r"keywordtranslation", KeywordTranslationViewSet)
-router.register(r'translationexample', TranslationExampleViewSet)
-router.register(r'tags', TagViewSet, basename='tag')
-router.register(r'category-tags', CategoryTagViewSet, basename='categorytag')
-router.register(r"category-parameters", CategoryParameterViewSet, basename="category-parameter")
+router.register(r"translationexample", TranslationExampleViewSet)
+router.register(r"tags", TagViewSet, basename="tag")
+router.register(r"category-tags", CategoryTagViewSet, basename="categorytag")
+router.register(
+    r"category-parameters", CategoryParameterViewSet, basename="category-parameter"
+)
 
 # router.register(r'keyword-translation', KeywordTranslationViewSet, basename='keyword-translation')
 
@@ -82,23 +101,59 @@ urlpatterns = [
     path("api/user/", UserView.as_view(), name="user data"),
     path("api/user/<int:user_id>", UserView.as_view(), name="user data"),
     path("api/browse/", DirectoryBrowseView.as_view(), name="directory-browse"),
-    path('api/complete-files/<int:auction_id>', CompleteFilesView.as_view(), name='complete_files'),
-    path('api/complete-auctionset-files/<int:auction_set_id>', CompleteAuctionSetFilesView.as_view(), name='complete_auctionset_files'),
+    path(
+        "api/complete-files/<int:auction_id>",
+        CompleteFilesView.as_view(),
+        name="complete_files",
+    ),
+    path(
+        "api/complete-auctionset-files/<int:auction_set_id>",
+        CompleteAuctionSetFilesView.as_view(),
+        name="complete_auctionset_files",
+    ),
     path(
         "api/browse/<path:path>", DirectoryBrowseView.as_view(), name="directory-browse"
     ),
     path("api/translations/", ListTranslationsView.as_view(), name="list_translations"),
-    path("api/translations/save/", SaveTranslationsView.as_view(), name="save_translations"),
-    path('keyword-translation/search/', KeywordTranslationSearchView.as_view(), name='keyword-translation-search'),
+    path(
+        "api/translations/save/",
+        SaveTranslationsView.as_view(),
+        name="save_translations",
+    ),
+    path(
+        "keyword-translation/search/",
+        KeywordTranslationSearchView.as_view(),
+        name="keyword-translation-search",
+    ),
     path("api/login/", LoginView.as_view(), name="login"),
     path("api/logout/", LogoutView.as_view(), name="logout"),
-    path('api/perform-ocr/', PerformOcrView.as_view(), name='perform_ocr'),
-    path('api/group-users/<str:group_name>/', ListGroupUsersView.as_view(), name='group_users'),
-    path('api/description-templates/user/<int:user_id>/', GetUsersDescriptionTemplates.as_view(), name='description_templates'),
-    path('api/keyword-translation/user/<int:user_id>/', GetUsersKeywordTranslation.as_view(), name='keyword_translation'),
-    path('api/image-rotate/', ImageRotateView.as_view(), name='image_rotate'),
-    path('distinct-auction-parameters/', DistinctAuctionParameterView.as_view(), name='distinct_auction_parameters'),
-    path('distinct-parameters/', DistinctParameterView.as_view(), name='distinct_parameters'),
+    path("api/perform-ocr/", PerformOcrView.as_view(), name="perform_ocr"),
+    path(
+        "api/group-users/<str:group_name>/",
+        ListGroupUsersView.as_view(),
+        name="group_users",
+    ),
+    path(
+        "api/description-templates/user/<int:user_id>/",
+        GetUsersDescriptionTemplates.as_view(),
+        name="description_templates",
+    ),
+    path(
+        "api/keyword-translation/user/<int:user_id>/",
+        GetUsersKeywordTranslation.as_view(),
+        name="keyword_translation",
+    ),
+    path("api/image-rotate/", ImageRotateView.as_view(), name="image_rotate"),
+    path(
+        "distinct-auction-parameters/",
+        DistinctAuctionParameterView.as_view(),
+        name="distinct_auction_parameters",
+    ),
+    path(
+        "distinct-parameters/",
+        DistinctParameterView.as_view(),
+        name="distinct_parameters",
+    ),
     path("allegro/login/", AllegroLoginView.as_view(), name="allegro_login"),
     path("allegro/callback/", AllegroCallbackView.as_view(), name="allegro_callback"),
     path(
@@ -121,11 +176,48 @@ urlpatterns = [
         GetModelStructure.as_view(),
         name="get_model_structure",
     ),
-    path('download/auctionset/<int:auctionset_id>/', download_auctionset_xlsx, name='download_auctionset_xlsx'),
-    path('auctionsets/baselinker/upload/<int:auctionset_id>', UploadAuctionSetToBaselinkerView.as_view(), name='upload_auctionset_to_baselinker'),
-    path('tag-preview/', PrepareTagFieldPreview.as_view(), name='tag_preview'),
-    path('api/translate/', TranslateView.as_view(), name='translate'),
-    path('api/translate-bl-products/', TranslateBaselinkerProductsView.as_view(), name='translate_bl_products'),
-    path('baselinker/inventories/', BaselinkerInventoriesView.as_view(), name='baselinker_inventories'),
-
+    path(
+        "download/auctionset/<int:auctionset_id>/",
+        download_auctionset_xlsx,
+        name="download_auctionset_xlsx",
+    ),
+    path(
+        "auctionsets/baselinker/upload/<int:auctionset_id>",
+        UploadAuctionSetToBaselinkerView.as_view(),
+        name="upload_auctionset_to_baselinker",
+    ),
+    path("tag-preview/", PrepareTagFieldPreview.as_view(), name="tag_preview"),
+    path("api/translate/", TranslateView.as_view(), name="translate"),
+    path(
+        "api/translate-bl-products/",
+        TranslateBaselinkerProductsView.as_view(),
+        name="translate_bl_products",
+    ),
+    path(
+        "baselinker/inventories/",
+        BaselinkerInventoriesView.as_view(),
+        name="baselinker_inventories",
+    ),
+    # Utility endpoints
+    path(
+        "utils/rows-to-columns/",
+        ConvertRowsToColumnsView.as_view(),
+        name="rows_to_columns",
+    ),
+    path(
+        "allegro/export/start/",
+        ExportAllegroStartView.as_view(),
+        name="export_allegro_start",
+    ),
+    path(
+        "allegro/export/download/",
+        DownloadAllegroExportView.as_view(),
+        name="export_allegro_download",
+    ),
+    path("auctions/export/", ExportAuctionsView.as_view(), name="export_auctions"),
+    path(
+        "auctions/export/download/",
+        DownloadAuctionsExportView.as_view(),
+        name="download_auctions_export",
+    ),
 ]


### PR DESCRIPTION
## Summary
- integrate Celery with basic configuration
- implement background tasks for Allegro and auction exports
- add utility views for CSV conversion and export download
- expose new endpoints in the router
- include Celery dependency

## Testing
- `python sell_that_sheet/manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847273ec7308328bd75f2b416564c4e