### PR TITLE
Fix Celery redis dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN pip install --no-cache-dir poetry
 
 # Copy the project files
 COPY pyproject.toml poetry.lock ./
-RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi \
+    && pip install redis
 
 # Copy Django app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 ---
 
+## Running Celery tasks
+
+Celery uses Redis as the message broker. The Python client library is not
+installed by default when using the source code directly. Install it before
+running any Celery tasks:
+
+```bash
+pip install redis
+```
+
+The provided Dockerfile already installs this dependency.
+
 ```mermaid
 erDiagram
     PHOTO {


### PR DESCRIPTION
## Summary
- install redis Python package in Docker build
- document the redis requirement for Celery tasks in README

## Testing
- `python -m compileall -q sell_that_sheet/sell_that_sheet`

------
https://chatgpt.com/codex/tasks/task_e_684f3c23da0083289dde53cd224f896d