### PR TITLE
Implement task status tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,5 @@ cython_debug/
 *.cnf
 
 docker-compose.yaml
+
+task_status.json

--- a/sell_that_sheet/sell_that_sheet/extra_views.py
+++ b/sell_that_sheet/sell_that_sheet/extra_views.py
@@ -9,7 +9,11 @@ from rest_framework.response import Response
 from rest_framework import status
 
 from .services.rows_to_columns import rows_to_columns
-from .tasks import export_allegro_catalogue_task, export_auctions_task
+from .tasks import (
+    export_allegro_catalogue_task,
+    export_auctions_task,
+    register_task,
+)
 
 
 class ConvertRowsToColumnsView(APIView):
@@ -41,6 +45,7 @@ class ConvertRowsToColumnsView(APIView):
 class ExportAllegroStartView(APIView):
     def post(self, request):
         task = export_allegro_catalogue_task.delay()
+        register_task("export_allegro_catalogue_task", task.id)
         return Response({"task_id": task.id})
 
 
@@ -59,6 +64,7 @@ class DownloadAllegroExportView(APIView):
 class ExportAuctionsView(APIView):
     def get(self, request):
         task = export_auctions_task.delay()
+        register_task("export_auctions_task", task.id)
         return Response({"task_id": task.id})
 
 

--- a/sell_that_sheet/sell_that_sheet/tasks.py
+++ b/sell_that_sheet/sell_that_sheet/tasks.py
@@ -1,43 +1,98 @@
 from celery import shared_task
 from django.conf import settings
+from django.utils import timezone
 from .services.allegroconnector import AllegroConnector
 from django.core.management import call_command
 import os
+import json
+
+STATUS_FILE = os.path.join(settings.BASE_DIR, "task_status.json")
 
 
-@shared_task
-def export_allegro_catalogue_task():
-    connector = AllegroConnector()
-    connector.get_allegro_access_token()
-    catalogue = connector.download_catalogue()
-    parsed = connector.parse_catalogue(catalogue)
-    output_path = os.path.join(settings.BASE_DIR, "full_catalogue.xlsx")
-    connector.export_to_xlsx(parsed, output_path)
-    return output_path
+def _load_statuses():
+    try:
+        with open(STATUS_FILE, "r") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {}
 
 
-@shared_task
-def export_auctions_task():
-    call_command("export_auctions")
-    return os.path.join(settings.BASE_DIR, "auctions_export.xlsx")
+def _save_statuses(data):
+    with open(STATUS_FILE, "w") as fh:
+        json.dump(data, fh)
+
+
+def register_task(task_name: str, task_id: str):
+    data = _load_statuses()
+    data[task_name] = {
+        "task_id": task_id,
+        "status": "PENDING",
+        "last_run": None,
+    }
+    _save_statuses(data)
+
+
+def update_task_status(task_name: str, task_id: str, status: str):
+    data = _load_statuses()
+    record = data.get(task_name, {})
+    record.update({"task_id": task_id, "status": status})
+    if status in {"SUCCESS", "FAILURE"}:
+        record["last_run"] = timezone.now().isoformat()
+    data[task_name] = record
+    _save_statuses(data)
+
+
+@shared_task(bind=True)
+def export_allegro_catalogue_task(self):
+    update_task_status("export_allegro_catalogue_task", self.request.id, "STARTED")
+    try:
+        connector = AllegroConnector()
+        connector.get_allegro_access_token()
+        catalogue = connector.download_catalogue()
+        parsed = connector.parse_catalogue(catalogue)
+        output_path = os.path.join(settings.BASE_DIR, "full_catalogue.xlsx")
+        connector.export_to_xlsx(parsed, output_path)
+        update_task_status(
+            "export_allegro_catalogue_task",
+            self.request.id,
+            "SUCCESS",
+        )
+        return output_path
+    except Exception:
+        update_task_status(
+            "export_allegro_catalogue_task",
+            self.request.id,
+            "FAILURE",
+        )
+        raise
+
+
+@shared_task(bind=True)
+def export_auctions_task(self):
+    update_task_status("export_auctions_task", self.request.id, "STARTED")
+    try:
+        call_command("export_auctions")
+        update_task_status("export_auctions_task", self.request.id, "SUCCESS")
+        return os.path.join(settings.BASE_DIR, "auctions_export.xlsx")
+    except Exception:
+        update_task_status("export_auctions_task", self.request.id, "FAILURE")
+        raise
 
 
 def get_tasks_status():
-    """
-    Returns the status of all tasks.
-    """
+    """Return status information for all known tasks."""
     from celery.result import AsyncResult
 
-    task_ids = [
-        "export_allegro_catalogue_task",
-        "export_auctions_task",
-    ]
+    data = _load_statuses()
     statuses = {}
-    for task_id in task_ids:
-        result = AsyncResult(task_id)
-        statuses[task_id] = {
-            "state": result.state,
-            "result": result.result,
-            "date_done": result.date_done,
+    for task_name, info in data.items():
+        task_id = info.get("task_id")
+        result = AsyncResult(task_id) if task_id else None
+        statuses[task_name] = {
+            "task_id": task_id,
+            "state": result.state if result else "UNKNOWN",
+            "result": result.result if result else None,
+            "date_done": getattr(result, "date_done", None) if result else None,
+            "last_run": info.get("last_run"),
         }
     return statuses

--- a/sell_that_sheet/sell_that_sheet/views.py
+++ b/sell_that_sheet/sell_that_sheet/views.py
@@ -1124,6 +1124,7 @@ class CeleryTaskManagerView(APIView):
                             'status': openapi.Schema(type=openapi.TYPE_STRING),
                             'result': openapi.Schema(type=openapi.TYPE_STRING),
                             'date_done': openapi.Schema(type=openapi.TYPE_STRING, format='date-time'),
+                            'last_run': openapi.Schema(type=openapi.TYPE_STRING, format='date-time'),
                         }
                     )
                 )


### PR DESCRIPTION
## Summary
- add helpers to store Celery task status information
- record tasks when they're triggered and when they finish
- expose last run timestamp via the existing status API
- ignore generated `task_status.json`

## Testing
- `python sell_that_sheet/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685038d89de88328abff767ecfe5973a