### PR TITLE
Add Baselinker product copy endpoint

### DIFF
--- a/sell_that_sheet/sell_that_sheet/urls.py
+++ b/sell_that_sheet/sell_that_sheet/urls.py
@@ -44,6 +44,7 @@ from .views import (
     CategoryParameterViewSet,
     TranslateBaselinkerProductsView,
     BaselinkerInventoriesView,
+    CopyBaselinkerProductWithImagesView,
     CeleryTaskManagerView,
 )
 from .extra_views import (
@@ -220,6 +221,11 @@ urlpatterns = [
         "bl-auctions/export/download/",
         DownloadAuctionsExportView.as_view(),
         name="download_auctions_export",
+    ),
+    path(
+        "bl-auctions/copy-with-images/",
+        CopyBaselinkerProductWithImagesView.as_view(),
+        name="bl_copy_with_images",
     ),
     path("tasks/status/", CeleryTaskManagerView.as_view(), name="tasks_status"),
 ]


### PR DESCRIPTION
## Summary
- implement `copy_product_with_images` in BaseLinkerService
- expose new API endpoint `CopyBaselinkerProductWithImagesView`
- wire endpoint in Django urls
- ensure inventory ID is sent as a string when copying products

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68616f47b2248328b4475bf985b6e000